### PR TITLE
Adding page-hover, no-hover, and group-page-hover

### DIFF
--- a/src/service/tailwind/twin.ts
+++ b/src/service/tailwind/twin.ts
@@ -198,6 +198,10 @@ export function twin(context: ContextModule): Tailwind.ConfigJS {
 				addSelector("page-xl", ".page-xl &")
 				addSelector("page-2xl", ".page-2xl &")
 
+				addSelector("page-hover", ".is-hoverable &:hover")
+				addSelector("no-hover", ":not(.is-hoverable &)")
+				addSelector("group-page-hover", ".is-hoverable .group:hover &")
+
 				return
 
 				function addMedia(variant: string, value: string) {


### PR DESCRIPTION
Adding the latest hover macros we use in pages.

`page-hover`: This works as hover but only if the device is capable of hovering. In the builder, this will work for a large browser container only.

`no-hover`: This works for devices that aren't capable of hovering. In the builder, this will work for a small browser container only.

`group-page-hover`: This works with the group class, the same as group-hover but for page-hover.